### PR TITLE
More APIs supported for messages.

### DIFF
--- a/AsyncWorldEdit/src/config.yml
+++ b/AsyncWorldEdit/src/config.yml
@@ -63,8 +63,10 @@ awe:
         #number of blocks on the player queue when to stop placing blocks
         limit-soft: 250000
       messages:
-        #Whether or not to show progress using BarAPI
-        progress-bar: true
+        #Which status API to use ('false' to disable, 'auto' to autodetect)
+        #Available options : ActionBarAPI, BarAPI, TitleManager, WelcomeTitle, BountifulAPI, ActionMessager
+        #A full server restart after a change of this setting is recommended.
+        status-api: auto
         #Whether or not to show progress using the chat messages
         progress-chat: true
         #is async world edit talkative 

--- a/AsyncWorldEdit/src/org/primesoft/asyncworldedit/blockPlacer/BlockPlacer.java
+++ b/AsyncWorldEdit/src/org/primesoft/asyncworldedit/blockPlacer/BlockPlacer.java
@@ -43,18 +43,17 @@ package org.primesoft.asyncworldedit.blockPlacer;
 import com.sk89q.worldedit.MaxChangedBlocksException;
 import org.bukkit.scheduler.BukkitScheduler;
 import org.primesoft.asyncworldedit.AsyncWorldEditMain;
-import org.primesoft.asyncworldedit.BarAPIntegrator;
 import org.primesoft.asyncworldedit.PhysicsWatch;
 import org.primesoft.asyncworldedit.blockPlacer.entries.JobEntry;
 import org.primesoft.asyncworldedit.blockPlacer.entries.UndoJob;
 import org.primesoft.asyncworldedit.configuration.ConfigProvider;
 import org.primesoft.asyncworldedit.configuration.PermissionGroup;
+import org.primesoft.asyncworldedit.livestatus.LiveStatus;
 import org.primesoft.asyncworldedit.permissions.Permission;
 import org.primesoft.asyncworldedit.playerManager.PlayerEntry;
 import org.primesoft.asyncworldedit.strings.MessageType;
 import org.primesoft.asyncworldedit.utils.FuncParamEx;
 import org.primesoft.asyncworldedit.utils.InOutParam;
-import org.primesoft.asyncworldedit.worldedit.ActionBarAPIntegrator;
 import org.primesoft.asyncworldedit.worldedit.AsyncTask;
 import org.primesoft.asyncworldedit.worldedit.CancelabeEditSession;
 import org.primesoft.asyncworldedit.worldedit.ThreadSafeEditSession;
@@ -117,15 +116,16 @@ public class BlockPlacer {
      */
     private long m_lastRunTime;
 
+    private LiveStatus m_status;
     /**
      * The bar API
      */
-    private final BarAPIntegrator m_barAPI;
+//    private final BarAPIntegrator m_barAPI;
 
     /**
      * Title API
      */
-    private final ActionBarAPIntegrator m_actionbarAPI;
+//    private final ActionBarAPIntegrator m_actionbarAPI;
 
     /**
      * List of all job added listeners
@@ -181,12 +181,10 @@ public class BlockPlacer {
         m_blocks = new HashMap<PlayerEntry, BlockPlacerPlayer>();
         m_lockedQueues = new HashSet<PlayerEntry>();
         m_scheduler = plugin.getServer().getScheduler();
-        m_barAPI = plugin.getBarAPI();
-        m_actionbarAPI = plugin.getActionBarAPI();
-
+//        m_barAPI = plugin.getBarAPI();
+//        m_actionbarAPI = plugin.getActionBarAPI();
         m_plugin = plugin;
         m_physicsWatcher = plugin.getPhysicsWatcher();
-
         loadConfig();
     }
 
@@ -867,8 +865,12 @@ public class BlockPlacer {
             entry.setMaxQueueBlocks(0);
         }
 
-        m_barAPI.disableMessage(player);
-        m_actionbarAPI.disableMessage(player);
+        //m_barAPI.disableMessage(player);
+        //m_actionbarAPI.disableMessage(player);
+        m_status = LiveStatus.LiveStatusSelector.getStatusAPI(player);
+
+        if(m_status!=null)
+            m_status.disableMessage(player);
     }
 
     /**
@@ -904,9 +906,10 @@ public class BlockPlacer {
             entry.setMaxQueueBlocks(newMax);
         }
 
-        String message = MessageType.CMD_JOBS_PROGRESS_BAR.format(jobs, speed, time);
-        m_barAPI.setMessage(player, message, percentage);
-        m_actionbarAPI.setMessage(player, message, percentage);
+        m_status = LiveStatus.LiveStatusSelector.getStatusAPI(player);
+
+        if(m_status!=null)
+            m_status.setMessage(player, blocks, maxBlocks, jobs, speed, time, percentage);
     }
 
     /**

--- a/AsyncWorldEdit/src/org/primesoft/asyncworldedit/configuration/PermissionGroup.java
+++ b/AsyncWorldEdit/src/org/primesoft/asyncworldedit/configuration/PermissionGroup.java
@@ -115,6 +115,8 @@ public class PermissionGroup {
      */
     private final boolean m_useBarApi;
 
+    private final String m_status;
+
     /**
      * Use chat to display progress
      */
@@ -215,6 +217,9 @@ public class PermissionGroup {
         return m_useBarApi;
     }
 
+    public String getStatusAPI() {
+        return m_status;
+    }
     /**
      * Use chat to display progress
      *
@@ -247,6 +252,7 @@ public class PermissionGroup {
         m_rendererBlocks = 10000;
         m_rendererTime = 40;
         m_useBarApi = true;
+        m_status = "auto";
         m_useChat = true;
         m_name = "default-values";
     }
@@ -310,6 +316,9 @@ public class PermissionGroup {
                 ? defaults.isChatProgressEnabled() : messagesSection.getBoolean("progress-chat", defaults.isChatProgressEnabled());
         m_isTalkative = messagesSection == null
                 ? defaults.isTalkative() : messagesSection.getBoolean("talkative", defaults.isTalkative());
+
+        m_status = messagesSection == null
+                ? defaults.getStatusAPI() : messagesSection.getString("status-api", defaults.getStatusAPI());
     }
 
     /**

--- a/AsyncWorldEdit/src/org/primesoft/asyncworldedit/livestatus/ActionBarAPIIntegrator.java
+++ b/AsyncWorldEdit/src/org/primesoft/asyncworldedit/livestatus/ActionBarAPIIntegrator.java
@@ -1,0 +1,50 @@
+package org.primesoft.asyncworldedit.livestatus;
+
+import com.connorlinfoot.actionbarapi.ActionBarAPI;
+import org.primesoft.asyncworldedit.playerManager.PlayerEntry;
+import org.primesoft.asyncworldedit.strings.MessageType;
+
+import javax.annotation.Nonnull;
+
+/**
+ * @author Weby@we-bb.com <Nicolas Glassey>
+ * @version 1.0.0
+ * @since 29/04/15
+ */
+public class ActionBarAPIIntegrator implements LiveStatus
+{
+    @Override
+    public void disableMessage(@Nonnull PlayerEntry player)
+    {
+        ActionBarAPI.sendActionBar(player.getPlayer(), "");
+    }
+
+    @Override
+    public void setMessage(@Nonnull PlayerEntry player, int blocks, int maxBlocks, int jobs, double speed, double time, double percentage)
+    {
+
+        String block_full =  "█";
+        String block_half =  "░";
+        int barAmount = 20;
+
+        String message = MessageType.CMD_JOBS_PROGRESS_BAR.format(jobs, speed, time);
+
+        if(message==null)
+            message="";
+        if(percentage<0) percentage=0;
+        if(percentage>100) percentage=100;
+
+        int increment = 100/barAmount;
+        int darkAmount = (int) percentage/increment;
+        int lightAmount = barAmount-darkAmount;
+
+        String bars = "";
+        for(int i = 0; i < darkAmount; i++)
+            bars+=block_full;
+        for(int i = 0; i < lightAmount; i++)
+            bars+=block_half;
+
+        message += " : "+bars+" "+(int) percentage+"%";
+        ActionBarAPI.sendActionBar(player.getPlayer(), message);
+    }
+}

--- a/AsyncWorldEdit/src/org/primesoft/asyncworldedit/livestatus/ActionMessagerIntegrator.java
+++ b/AsyncWorldEdit/src/org/primesoft/asyncworldedit/livestatus/ActionMessagerIntegrator.java
@@ -1,0 +1,57 @@
+package org.primesoft.asyncworldedit.livestatus;
+
+import net.sneling.actionmessager.ActionMessager;
+import org.primesoft.asyncworldedit.AsyncWorldEditMain;
+import org.primesoft.asyncworldedit.playerManager.PlayerEntry;
+import org.primesoft.asyncworldedit.strings.MessageType;
+
+import javax.annotation.Nonnull;
+
+/**
+ * @author Weby@we-bb.com <Nicolas Glassey>
+ * @version 1.0.0
+ * @since 30/04/15
+ */
+public class ActionMessagerIntegrator implements LiveStatus
+{
+    final ActionMessager am = (ActionMessager) AsyncWorldEditMain.getInstance().getServer().getPluginManager().getPlugin("ActionMessager");
+
+    @Override
+    public void disableMessage(@Nonnull PlayerEntry player)
+    {
+        if(am!=null)
+            am.sendMessage(player.getPlayer(), "");
+    }
+
+    @Override
+    public void setMessage(@Nonnull PlayerEntry player, int blocks, int maxBlocks, int jobs, double speed, double time, double percentage)
+    {
+        if(am!=null)
+        {
+            String block_full = "█";
+            String block_half = "░";
+            int barAmount = 20;
+
+            String message = MessageType.CMD_JOBS_PROGRESS_BAR.format(jobs, speed, time);
+
+            if (message == null)
+                message = "";
+            if (percentage < 0) percentage = 0;
+            if (percentage > 100) percentage = 100;
+
+            int increment = 100 / barAmount;
+            int darkAmount = (int) percentage / increment;
+            int lightAmount = barAmount - darkAmount;
+
+            String bars = "";
+            for (int i = 0; i < darkAmount; i++)
+                bars += block_full;
+            for (int i = 0; i < lightAmount; i++)
+                bars += block_half;
+
+            message += " : " + bars + " " + (int) percentage + "%";
+
+            am.sendMessage(player.getPlayer(), message);
+        }
+    }
+}

--- a/AsyncWorldEdit/src/org/primesoft/asyncworldedit/livestatus/BarAPIIntegrator.java
+++ b/AsyncWorldEdit/src/org/primesoft/asyncworldedit/livestatus/BarAPIIntegrator.java
@@ -1,0 +1,35 @@
+package org.primesoft.asyncworldedit.livestatus;
+
+import me.confuser.barapi.BarAPI;
+import org.primesoft.asyncworldedit.playerManager.PlayerEntry;
+import org.primesoft.asyncworldedit.strings.MessageType;
+
+import javax.annotation.Nonnull;
+
+/**
+ * @author Weby@we-bb.com <Nicolas Glassey>
+ * @version 1.0.0
+ * @since 29/04/15
+ */
+public class BarAPIIntegrator implements LiveStatus
+{
+
+    @Override
+    public void disableMessage(@Nonnull PlayerEntry player)
+    {
+        BarAPI.removeBar(player.getPlayer());
+    }
+
+    @Override
+    public void setMessage(@Nonnull PlayerEntry player, int blocks, int maxBlocks, int jobs, double speed, double time, double percentage)
+    {
+        String message = MessageType.CMD_JOBS_PROGRESS_BAR.format(jobs, speed, time);
+
+        if(message==null)
+            message="";
+        if(percentage<0) percentage=0;
+        if(percentage>100) percentage=100;
+
+        BarAPI.setMessage(player.getPlayer(), message, (float) percentage);
+    }
+}

--- a/AsyncWorldEdit/src/org/primesoft/asyncworldedit/livestatus/BountifulAPIIntegrator.java
+++ b/AsyncWorldEdit/src/org/primesoft/asyncworldedit/livestatus/BountifulAPIIntegrator.java
@@ -1,0 +1,49 @@
+package org.primesoft.asyncworldedit.livestatus;
+
+import com.connorlinfoot.bountifulapi.BountifulAPI;
+import org.primesoft.asyncworldedit.playerManager.PlayerEntry;
+import org.primesoft.asyncworldedit.strings.MessageType;
+
+import javax.annotation.Nonnull;
+
+/**
+ * @author Weby@we-bb.com <Nicolas Glassey>
+ * @version 1.0.0
+ * @since 30/04/15
+ */
+public class BountifulAPIIntegrator implements LiveStatus
+{
+    @Override
+    public void disableMessage(@Nonnull PlayerEntry player)
+    {
+        BountifulAPI.sendActionBar(player.getPlayer(), "");
+    }
+
+    @Override
+    public void setMessage(@Nonnull PlayerEntry player, int blocks, int maxBlocks, int jobs, double speed, double time, double percentage)
+    {
+        String block_full =  "█";
+        String block_half =  "░";
+        int barAmount = 20;
+
+        String message = MessageType.CMD_JOBS_PROGRESS_BAR.format(jobs, speed, time);
+
+        if(message==null)
+            message="";
+        if(percentage<0) percentage=0;
+        if(percentage>100) percentage=100;
+
+        int increment = 100/barAmount;
+        int darkAmount = (int) percentage/increment;
+        int lightAmount = barAmount-darkAmount;
+
+        String bars = "";
+        for(int i = 0; i < darkAmount; i++)
+            bars+=block_full;
+        for(int i = 0; i < lightAmount; i++)
+            bars+=block_half;
+
+        message += " : "+bars+" "+(int) percentage+"%";
+        BountifulAPI.sendActionBar(player.getPlayer(), message);
+    }
+}

--- a/AsyncWorldEdit/src/org/primesoft/asyncworldedit/livestatus/LiveStatus.java
+++ b/AsyncWorldEdit/src/org/primesoft/asyncworldedit/livestatus/LiveStatus.java
@@ -1,0 +1,169 @@
+package org.primesoft.asyncworldedit.livestatus;
+
+import org.bukkit.plugin.Plugin;
+import org.bukkit.plugin.java.JavaPlugin;
+import org.primesoft.asyncworldedit.AsyncWorldEditMain;
+import org.primesoft.asyncworldedit.playerManager.PlayerEntry;
+
+import javax.annotation.Nonnull;
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+
+/**
+ * @author Weby@we-bb.com <Nicolas Glassey>
+ * @version 1.0.0
+ * @since 29/04/15
+ */
+public interface LiveStatus
+{
+    class LiveStatusSelector
+    {
+        public static List<LiveStatus> checkJars(JavaPlugin plugin, List<LiveStatus> loaded) {
+            List<LiveStatus> existing = new ArrayList<LiveStatus>();
+            Plugin[] plugins = plugin.getServer().getPluginManager().getPlugins();
+            List<String> pluginsNames = new ArrayList<String>();
+            for(Plugin p : plugins)
+                pluginsNames.add(p.getName().toLowerCase());
+
+            for(LiveStatus implementation : loaded)
+            {
+                String cName = implementation.getClass().getSimpleName().replace("Integrator", "");
+                if(pluginsNames.contains(cName.toLowerCase()))
+                {
+                    existing.add(implementation);
+                }
+            }
+            return existing;
+        }
+        public static List<LiveStatus> loadStatusAPIs(JavaPlugin plugin, ClassLoader classLoader)
+        {
+            List<LiveStatus> implementations = new ArrayList<LiveStatus>();
+            if(classLoader!=null)
+            {
+                Package p = LiveStatus.class.getPackage();
+                ArrayList<Class> classes = new ArrayList<Class>();
+
+                File directory = null;
+                String fullPath;
+                String pkgname = p.getName();
+                String relPath = pkgname.replace(".", "/");
+
+                URL resource = classLoader.getResource(relPath);
+                if(resource!=null)
+                {
+
+                    fullPath = resource.getFile();
+
+                    try
+                    {
+                        directory = new File(resource.toURI());
+                    } catch (URISyntaxException e)
+                    {
+                        e.printStackTrace();
+                    } catch (IllegalArgumentException e)
+                    {
+                        directory = null;
+                    }
+
+                    if (directory != null && directory.exists())
+                    {
+                        String[] files = directory.list();
+                        for (String file : files)
+                        {
+                            if (file.endsWith(".class"))
+                            {
+                                String className = pkgname + "." + file.substring(0, file.length() - 6);
+                                try
+                                {
+                                    classes.add(Class.forName(className));
+                                } catch (ClassNotFoundException e)
+                                {
+                                    e.printStackTrace();
+                                }
+                            }
+                        }
+                    } else
+                    {
+                        try
+                        {
+                            String jarPath = fullPath.replaceFirst("[.]jar[!].*", ".jar").replaceFirst("file:", "");
+                            JarFile jarFile = new JarFile(jarPath);
+                            Enumeration<JarEntry> entries = jarFile.entries();
+                            while (entries.hasMoreElements())
+                            {
+                                JarEntry entry = entries.nextElement();
+                                String entryName = entry.getName();
+                                if (entryName.startsWith(relPath) && entryName.length() > (relPath.length() + "/".length()))
+                                {
+                                    String className = entryName.replace('/', '.').replace('\\', '.').replace(".class", "");
+                                    try
+                                    {
+                                        classes.add(Class.forName(className));
+                                    } catch (ClassNotFoundException e)
+                                    {
+                                        e.printStackTrace();
+                                    }
+                                }
+                            }
+                        } catch (IOException e)
+                        {
+                            e.printStackTrace();
+                        }
+                    }
+                }
+                for(Class clazz : classes)
+                {
+                    if(LiveStatus.class.isAssignableFrom(clazz) && !clazz.isInterface())
+                    {
+                        try
+                        {
+                            implementations.add((LiveStatus) clazz.newInstance());
+                        } catch (InstantiationException e)
+                        {
+                            e.printStackTrace();
+                        } catch (IllegalAccessException e)
+                        {
+                            e.printStackTrace();
+                        }
+                    }
+                }
+            }
+            return implementations;
+        }
+        public static LiveStatus getStatusAPI(PlayerEntry player)
+        {
+            LiveStatus ls=null;
+            if(player!=null)
+            {
+                List<LiveStatus> available = AsyncWorldEditMain.getAvailableStatusAPIs();
+                if(available.size()>0)
+                {
+                    String sapi = player.getPermissionGroup().getStatusAPI();
+                    if(sapi.equalsIgnoreCase("auto"))
+                    {
+                        ls = available.get(0);
+                    }
+                    for(LiveStatus l : available)
+                    {
+                        if(l.getClass().getSimpleName().replace("Integrator","").equalsIgnoreCase(sapi))
+                        {
+                            return l;
+                        }
+                    }
+                }
+            }
+            return ls;
+        }
+    }
+
+    void disableMessage(@Nonnull PlayerEntry player);
+
+    void setMessage(@Nonnull PlayerEntry player, int blocks, int maxBlocks, int jobs, double speed, double time, double percentage);
+}

--- a/AsyncWorldEdit/src/org/primesoft/asyncworldedit/livestatus/TitleManagerIntegrator.java
+++ b/AsyncWorldEdit/src/org/primesoft/asyncworldedit/livestatus/TitleManagerIntegrator.java
@@ -1,0 +1,51 @@
+package org.primesoft.asyncworldedit.livestatus;
+
+import io.puharesource.mc.titlemanager.api.ActionbarTitleObject;
+import org.primesoft.asyncworldedit.playerManager.PlayerEntry;
+import org.primesoft.asyncworldedit.strings.MessageType;
+
+import javax.annotation.Nonnull;
+
+/**
+ * @author Weby@we-bb.com <Nicolas Glassey>
+ * @version 1.0.0
+ * @since 29/04/15
+ */
+public class TitleManagerIntegrator implements LiveStatus
+{
+    @Override
+    public void disableMessage(@Nonnull PlayerEntry player)
+    {
+        new ActionbarTitleObject("").send(player.getPlayer());
+    }
+
+    @Override
+    public void setMessage(@Nonnull PlayerEntry player, int blocks, int maxBlocks, int jobs, double speed, double time, double percentage)
+    {
+
+        String block_full =  "█";
+        String block_half =  "░";
+        int barAmount = 20;
+
+        String message = MessageType.CMD_JOBS_PROGRESS_BAR.format(jobs, speed, time);
+
+        if(message==null)
+            message="";
+        if(percentage<0) percentage=0;
+        if(percentage>100) percentage=100;
+
+        int increment = 100/barAmount;
+        int darkAmount = (int) percentage/increment;
+        int lightAmount = barAmount-darkAmount;
+
+        String bars = "";
+        for(int i = 0; i < darkAmount; i++)
+            bars+=block_full;
+        for(int i = 0; i < lightAmount; i++)
+            bars+=block_half;
+
+        message += " : "+bars+" "+(int) percentage+"%";
+
+        new ActionbarTitleObject(message).send(player.getPlayer());
+    }
+}

--- a/AsyncWorldEdit/src/org/primesoft/asyncworldedit/livestatus/WelcomeTitleIntegrator.java
+++ b/AsyncWorldEdit/src/org/primesoft/asyncworldedit/livestatus/WelcomeTitleIntegrator.java
@@ -1,0 +1,49 @@
+package org.primesoft.asyncworldedit.livestatus;
+
+import me.maxedoutfreaky.welcometitle.Manager;
+import org.primesoft.asyncworldedit.playerManager.PlayerEntry;
+import org.primesoft.asyncworldedit.strings.MessageType;
+
+import javax.annotation.Nonnull;
+
+/**
+ * @author Weby@we-bb.com <Nicolas Glassey>
+ * @version 1.0.0
+ * @since 30/04/15
+ */
+public class WelcomeTitleIntegrator implements LiveStatus
+{
+    @Override
+    public void disableMessage(@Nonnull PlayerEntry player)
+    {
+        Manager.getInstance().sendActionBar(player.getPlayer(), "");
+    }
+
+    @Override
+    public void setMessage(@Nonnull PlayerEntry player, int blocks, int maxBlocks, int jobs, double speed, double time, double percentage)
+    {
+        String block_full =  "█";
+        String block_half =  "░";
+        int barAmount = 20;
+
+        String message = MessageType.CMD_JOBS_PROGRESS_BAR.format(jobs, speed, time);
+
+        if(message==null)
+            message="";
+        if(percentage<0) percentage=0;
+        if(percentage>100) percentage=100;
+
+        int increment = 100/barAmount;
+        int darkAmount = (int) percentage/increment;
+        int lightAmount = barAmount-darkAmount;
+
+        String bars = "";
+        for(int i = 0; i < darkAmount; i++)
+            bars+=block_full;
+        for(int i = 0; i < lightAmount; i++)
+            bars+=block_half;
+
+        message += " : "+bars+" "+(int) percentage+"%";
+        Manager.getInstance().sendActionBar(player.getPlayer(), message);
+    }
+}

--- a/AsyncWorldEdit/src/org/primesoft/asyncworldedit/strings/MessageType.java
+++ b/AsyncWorldEdit/src/org/primesoft/asyncworldedit/strings/MessageType.java
@@ -40,8 +40,6 @@
  */
 package org.primesoft.asyncworldedit.strings;
 
-import org.bukkit.ChatColor;
-
 /**
  *
  * @author SBPrime


### PR DESCRIPTION
Config.yml : remove progress-bar: true/false with "status-api" field.
Available options : auto,false,ActionBarAPI, BarAPI, TitleManager, WelcomeTitle, BountifulAPI, ActionMessager. All of those are currently working (ActionMessager and WelcomeTitle only work with 1.8 (v1_8_R1, nms)).

AsyncWorldEdit will now search inside the "livestatus" package for compatible APIs, automatically. There is no list to maintain anywhere.
To create more compatible APIs, simply create a new class named <NameOfAPIToUse>Integrator, that implements LiveStatus. Do NOT create references to other plugins outside the overriden methods, since those classes will ALL be loaded in onEnable.

After they're loaded, AWE will check what .jars are loaded, compare with the list of livestatus integrators, and "allow" to use only those. So, if in configuration, you enter BountifulAPI and that plugin isn't installed, it simply won't work, but won't complain either. (you should maybe make it revert to "auto" if not found ?)

The "auto" setting will simply take the first item in the available livestatus integrators. Very useful if people just drop their .jar without configuring, it'll automagically use the one plugin that's installed. Assuming they use both BarAPI and TitleManager, only one of those two will be used.