### PR TITLE
Fix version checking

### DIFF
--- a/AsyncWorldEdit/src/main/java/org/primesoft/asyncworldedit/versionChecker/VersionChecker.java
+++ b/AsyncWorldEdit/src/main/java/org/primesoft/asyncworldedit/versionChecker/VersionChecker.java
@@ -68,7 +68,7 @@ public class VersionChecker {
     /**
      * AWE plugin ID
      */
-    private static final int PLUGIN_ID = 9661;
+    private static final int PLUGIN_ID = 327;
 
     /**
      * Spigo API url


### PR DESCRIPTION
It was using Spigot's [Premium version resource](https://www.spigotmc.org/resources/asyncworldedit-premium.9661/) rather than the [standard version](https://www.spigotmc.org/resources/asyncworldedit.327/) one.